### PR TITLE
ci(sync-cli): fix ci build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - yarn test
   - codecov
 deploy:
+  edge: true
   provider: npm
   email: "paulosales@gmail.com"
   api_key: "$NPM_API_KEY"


### PR DESCRIPTION
To know more about the travis-ci bug, read these posts:

https://travis-ci.community/t/no-stash-entries-found-missing-api-key-failed-to-deploy/6029
https://travis-ci.community/t/missing-api-key-when-deploying-to-github-releases/5761/14